### PR TITLE
LPM: allow a peer LPAR to coordinate the LPM test

### DIFF
--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -47,6 +47,14 @@ class LPM(Test):
         set up required packages and gather necessary test inputs
         '''
         self.install_packages()
+        self.using_peer = False
+        if self.params.get("lpar", default='') and self.params.get("lpar_ip", default=''):
+            self.lpar = self.params.get("lpar", default='')
+            self.lpar_ip = self.params.get("lpar_ip", default='')
+            self.lpar_user = self.params.get("lpar_user", default='root')
+            self.lpar_pwd = self.params.get("lpar_pwd", "*", default='********')
+            self.server = self.lpar[0:self.lpar.find('-')]
+            self.using_peer = True
         self.rsct_service_start()
 
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
@@ -56,32 +64,27 @@ class LPM(Test):
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default='********')
         self.options = self.params.get("options", default='')
         self.net_device_type = self.params.get("net_device_type", default='')
-
-        if not self.params.get("lpar", default=''):
+        if not self.using_peer:
             self.lpar = self.get_partition_name("Partition Name")
             self.log.info("'lpar' parameter empty, migrating current LPAR")
-        else:
-            self.lpar = self.params.get("lpar", default='')
-        if not self.lpar:
-            self.cancel("LPAR Name not got from lparstat command")
-        if not self.params.get("lpar_ip", default=''):
+            if not self.lpar:
+                self.cancel("LPAR Name not got from lparstat command")
             self.lpar_ip = self.get_mcp_component("MNName")
             self.log.info("'lpar_ip' parameter empty, migrating current LPAR")
-        else:
-            self.lpar_ip = self.params.get("lpar_ip", default='')
-        if not self.lpar_ip:
-            self.cancel("LPAR IP not got from lsrsrc command")
+            if not self.lpar_ip:
+                self.cancel("LPAR IP not got from lsrsrc command")
         self.session = Session(self.hmc_ip, user=self.hmc_user,
                                password=self.hmc_pwd)
         if not self.session.connect():
             self.cancel("failed connecting to HMC")
         cmd = 'lssyscfg -r sys -F name'
         output = self.session.cmd(cmd)
-        self.server = ''
-        for line in output.stdout_text.splitlines():
-            if line in self.lpar:
-                self.server = line
-                break
+        if not self.using_peer: 
+            self.server = ''
+            for line in output.stdout_text.splitlines():
+                if line in self.lpar:
+                    self.server = line
+                    break
         if not self.server:
             self.cancel("Managed System not got")
 
@@ -172,17 +175,25 @@ class LPM(Test):
         Running rsct services which is necessary for Network
         virtualization tests
         '''
-        try:
-            for svc in ["rsct", "rsct_rm"]:
-                process.run('startsrc -g %s' % svc, shell=True, sudo=True)
-        except CmdError as details:
-            self.log.debug(str(details))
-            self.fail("Starting service %s failed", svc)
+        if not self.using_peer:
+            try:
+                for svc in ["rsct", "rsct_rm"]:
+                    process.run('startsrc -g %s' % svc, shell=True, sudo=True)
+            except CmdError as details:
+                self.log.debug(str(details))
+                self.fail("Starting service %s failed", svc)
 
-        output = process.system_output("lssrc -a", ignore_status=True,
-                                       shell=True, sudo=True).decode("utf-8")
-        if "inoperative" in output:
-            self.fail("Failed to start the rsct and rsct_rm services")
+            output = process.system_output("lssrc -a", ignore_status=True,
+                                            shell=True, sudo=True).decode("utf-8")
+            if "inoperative" in output:
+                self.fail("Failed to start the rsct and rsct_rm services")
+        else:
+            self.peer_session = Session(self.lpar_ip, user = self.lpar_user, password = self.lpar_pwd)
+            if not self.peer_session.connect():
+                self.cancel("failed connecting to peer lpar")
+            for svc in ["rsct", "rsct_rm"]:
+                cmd = 'startsrc -g ' + svc
+                output = self.peer_session.cmd(cmd)
 
     def is_RMC_active(self, server):
         '''

--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -62,11 +62,9 @@ class LPM(Test):
             self.using_peer = True
         else:
             self.lpar = self.get_partition_name("Partition Name")
-            self.log.info("'lpar' parameter empty, migrating current LPAR")
             if not self.lpar:
                 self.cancel("LPAR Name not got from lparstat command")
             self.lpar_ip = self.get_mcp_component("MNName")
-            self.log.info("'lpar_ip' parameter empty, migrating current LPAR")
             if not self.lpar_ip:
                 self.cancel("LPAR IP not got from lsrsrc command")
         self.rsct_service_start()
@@ -183,7 +181,7 @@ class LPM(Test):
             for svc in ["rsct", "rsct_rm"]:
                 cmd = 'startsrc -g %s' % svc
                 if self.using_peer: 
-                    output = self.peer_session.cmd(cmd)
+                    self.peer_session.cmd(cmd)
                 else: 
                     process.run(cmd, shell=True, sudo=True) 
         except CmdError as details:

--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -47,6 +47,14 @@ class LPM(Test):
         set up required packages and gather necessary test inputs
         '''
         self.install_packages()
+        self.using_peer = False
+        if self.params.get("lpar", default='') and self.params.get("lpar_ip", default=''):
+            self.lpar = self.params.get("lpar", default='')
+            self.lpar_ip = self.params.get("lpar_ip", default='')
+            self.lpar_user = self.params.get("lpar_user", default='root')
+            self.lpar_pwd = self.params.get("lpar_pwd", "*", default='********')
+            self.server = self.lpar[0:self.lpar.find('-')]
+            self.using_peer = True
         self.rsct_service_start()
 
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
@@ -56,23 +64,27 @@ class LPM(Test):
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default='********')
         self.options = self.params.get("options", default='')
         self.net_device_type = self.params.get("net_device_type", default='')
-        self.lpar = self.get_partition_name("Partition Name")
-        if not self.lpar:
-            self.cancel("LPAR Name not got from lparstat command")
-        self.lpar_ip = self.get_mcp_component("MNName")
-        if not self.lpar_ip:
-            self.cancel("LPAR IP not got from lsrsrc command")
+        if not self.using_peer:
+            self.lpar = self.get_partition_name("Partition Name")
+            self.log.info("'lpar' parameter empty, migrating current LPAR")
+            if not self.lpar:
+                self.cancel("LPAR Name not got from lparstat command")
+            self.lpar_ip = self.get_mcp_component("MNName")
+            self.log.info("'lpar_ip' parameter empty, migrating current LPAR")
+            if not self.lpar_ip:
+                self.cancel("LPAR IP not got from lsrsrc command")
         self.session = Session(self.hmc_ip, user=self.hmc_user,
                                password=self.hmc_pwd)
         if not self.session.connect():
             self.cancel("failed connecting to HMC")
         cmd = 'lssyscfg -r sys -F name'
         output = self.session.cmd(cmd)
-        self.server = ''
-        for line in output.stdout_text.splitlines():
-            if line in self.lpar:
-                self.server = line
-                break
+        if not self.using_peer: 
+            self.server = ''
+            for line in output.stdout_text.splitlines():
+                if line in self.lpar:
+                    self.server = line
+                    break
         if not self.server:
             self.cancel("Managed System not got")
 
@@ -163,17 +175,25 @@ class LPM(Test):
         Running rsct services which is necessary for Network
         virtualization tests
         '''
-        try:
-            for svc in ["rsct", "rsct_rm"]:
-                process.run('startsrc -g %s' % svc, shell=True, sudo=True)
-        except CmdError as details:
-            self.log.debug(str(details))
-            self.fail("Starting service %s failed", svc)
+        if not self.using_peer:
+            try:
+                for svc in ["rsct", "rsct_rm"]:
+                    process.run('startsrc -g %s' % svc, shell=True, sudo=True)
+            except CmdError as details:
+                self.log.debug(str(details))
+                self.fail("Starting service %s failed", svc)
 
-        output = process.system_output("lssrc -a", ignore_status=True,
-                                       shell=True, sudo=True).decode("utf-8")
-        if "inoperative" in output:
-            self.fail("Failed to start the rsct and rsct_rm services")
+            output = process.system_output("lssrc -a", ignore_status=True,
+                                            shell=True, sudo=True).decode("utf-8")
+            if "inoperative" in output:
+                self.fail("Failed to start the rsct and rsct_rm services")
+        else:
+            self.peer_session = Session(self.lpar_ip, user = self.lpar_user, password = self.lpar_pwd)
+            if not self.peer_session.connect():
+                self.cancel("failed connecting to peer lpar")
+            for svc in ["rsct", "rsct_rm"]:
+                cmd = 'startsrc -g ' + svc
+                output = self.peer_session.cmd(cmd)
 
     def is_RMC_active(self, server):
         '''

--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -51,6 +51,7 @@ class LPM(Test):
         if self.params.get("lpar", default='') and \
                             self.params.get("lpar_ip", default=''):
             self.lpar = self.params.get("lpar", default='')
+            self.log.info("Migrating %s partition", self.lpar)
             self.lpar_ip = self.params.get("lpar_ip", default='')
             self.lpar_user = self.params.get("lpar_user", default='root')
             self.lpar_pwd = self.params.get("lpar_pwd", "*", 

--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -56,10 +56,10 @@ class LPM(Test):
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default='********')
         self.options = self.params.get("options", default='')
         self.net_device_type = self.params.get("net_device_type", default='')
-        self.lpar = self.get_partition_name("Partition Name")
+        self.lpar = self.params.get("lpar", default='')
         if not self.lpar:
             self.cancel("LPAR Name not got from lparstat command")
-        self.lpar_ip = self.get_mcp_component("MNName")
+        self.lpar_ip = self.params.get("lpar_ip", default='')
         if not self.lpar_ip:
             self.cancel("LPAR IP not got from lsrsrc command")
         self.session = Session(self.hmc_ip, user=self.hmc_user,

--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -56,10 +56,19 @@ class LPM(Test):
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default='********')
         self.options = self.params.get("options", default='')
         self.net_device_type = self.params.get("net_device_type", default='')
-        self.lpar = self.params.get("lpar", default='')
+
+        if not self.params.get("lpar", default=''):
+            self.lpar = self.get_partition_name("Partition Name")
+            self.log.info("'lpar' parameter empty, migrating current LPAR")
+        else:
+            self.lpar = self.params.get("lpar", default='')
         if not self.lpar:
             self.cancel("LPAR Name not got from lparstat command")
-        self.lpar_ip = self.params.get("lpar_ip", default='')
+        if not self.params.get("lpar_ip", default=''):
+            self.lpar_ip = self.get_mcp_component("MNName")
+            self.log.info("'lpar_ip' parameter empty, migrating current LPAR")
+        else:
+            self.lpar_ip = self.params.get("lpar_ip", default='')
         if not self.lpar_ip:
             self.cancel("LPAR IP not got from lsrsrc command")
         self.session = Session(self.hmc_ip, user=self.hmc_user,

--- a/io/net/virt-net/lpm.py.data/lpm.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm.yaml
@@ -1,3 +1,5 @@
 hmc_pwd:
 hmc_username:
 remote_server:
+lpar_ip:
+lpar:

--- a/io/net/virt-net/lpm.py.data/lpm.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm.yaml
@@ -1,4 +1,3 @@
 hmc_pwd:
 hmc_username:
 remote_server:
-

--- a/io/net/virt-net/lpm.py.data/lpm_5_iterations_from_peer.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_5_iterations_from_peer.yaml
@@ -1,0 +1,21 @@
+hmc_pwd:
+hmc_username:
+slot_num:
+vios_names:
+remote_server:
+remote_vios_names:
+sriov_adapters:
+sriov_ports:
+remote_sriov_adapters:
+remote_sriov_ports:
+bandwidth:
+lpar:
+lpar_ip:
+options: "--vniccfg 2"
+iteration: !mux
+    default: !mux
+        1:
+        2:
+        3:
+        4:
+        5:

--- a/io/net/virt-net/lpm.py.data/lpm_from_peer.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_from_peer.yaml
@@ -3,4 +3,3 @@ hmc_username:
 remote_server:
 lpar_ip:
 lpar:
-

--- a/io/net/virt-net/lpm.py.data/lpm_from_peer.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_from_peer.yaml
@@ -1,4 +1,6 @@
 hmc_pwd:
 hmc_username:
 remote_server:
+lpar_ip:
+lpar:
 

--- a/io/net/virt-net/lpm.py.data/lpm_from_peer.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_from_peer.yaml
@@ -1,0 +1,5 @@
+hmc_pwd:
+hmc_username:
+remote_server:
+lpar_ip:
+lpar:


### PR DESCRIPTION
Currently the LPM tests are self-validating; the LPAR being migrated is also the LPAR running the test. This fix allows an external LPAR to test migration of another LPAR.

Signed-off-by: Matthew Merck <merckmatthew@gmail.com>