### PR TITLE
Fixes for lpm_withvnic test

### DIFF
--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -309,7 +309,7 @@ class LPM(Test):
         """
         self.log.info("Gathering kernel errors if any")
         try:
-            dmesg.collect_errors_by_level()
+            dmesg.collect_errors_by_level(4)
         except Exception as exc:
             self.log.info(exc)
             self.fail("test failed,check dmesg log in debug log")

--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -299,9 +299,8 @@ class LPM(Test):
                               self.remote_adapter_id[index],
                               self.remote_ports[index], self.bandwidth,
                               self.adapter_id[index], self.ports[index]]:
-                    l_cmd.append(param)
+                    l_cmd.append(param.strip("\n"))
                 cmd.append("/".join(l_cmd))
-
         return " -i \"vnic_mappings=\\\"%s\\\"\" " % ",".join(cmd)
 
     def check_dmesg_error(self):

--- a/io/net/virt-net/lpm.py.data/lpm_withvnic.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_withvnic.yaml
@@ -1,13 +1,13 @@
-hmc_pwd:
-hmc_username:
-slot_num:
-vios_names:
-remote_server:
-remote_vios_names:
-sriov_adapters:
-sriov_ports:
-remote_sriov_adapters:
-remote_sriov_ports:
-bandwidth:
+hmc_pwd: "abc123"
+hmc_username: "hscroot"
+slot_num: "3"
+vios_names: "ltcbr33-vios1 ltcbr33-vios2" 
+remote_server: "ltcbr34"
+remote_vios_names: "ltcbr34-vios1 ltcbr34-vios2"
+sriov_adapters: "U78CA.001.CSS004F-P1-C6 U78CA.001.CSS004F-P1-C6"
+sriov_ports: "0 1"
+remote_sriov_adapters: "U78CA.001.CSS004Y-P1-C7 U78CA.001.CSS004Y-P1-C7"
+remote_sriov_ports: "0 1"
+bandwidth: "2"
 net_device_type: "vnic"
-options: "--vniccfg 2"
+options: ""

--- a/io/net/virt-net/lpm.py.data/lpm_withvnic.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_withvnic.yaml
@@ -1,13 +1,13 @@
-hmc_pwd: "abc123"
-hmc_username: "hscroot"
-slot_num: "3"
-vios_names: "ltcbr33-vios1 ltcbr33-vios2" 
-remote_server: "ltcbr34"
-remote_vios_names: "ltcbr34-vios1 ltcbr34-vios2"
-sriov_adapters: "U78CA.001.CSS004F-P1-C6 U78CA.001.CSS004F-P1-C6"
-sriov_ports: "0 1"
-remote_sriov_adapters: "U78CA.001.CSS004Y-P1-C7 U78CA.001.CSS004Y-P1-C7"
-remote_sriov_ports: "0 1"
-bandwidth: "2"
+hmc_pwd:
+hmc_username:
+slot_num:
+vios_names:
+remote_server:
+remote_vios_names:
+sriov_adapters:
+sriov_ports:
+remote_sriov_adapters:
+remote_sriov_ports:
+bandwidth:
 net_device_type: "vnic"
-options: ""
+options: "--vniccfg 2"


### PR DESCRIPTION
Remove newline characters that currently get into the migrlpar parameters creating in form_virt_net_options() and also change dmesg error level to 4 to stop the tests from failing on warnings